### PR TITLE
Feature: migrate to encoding/json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 
 format:
 	go fmt '$(PROJECT_ROOT)/...'
+	go mod tidy
 
 test: format
 	go test '$(PROJECT_ROOT)/...' | sed '/^?/d'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ on a live system.
 
 ### Prerequisites
 
-Requires Go v1.16 or newer (tested on 1.19 and 1.20 only).
+Requires Go v1.25 or newer.
 
 ### Building
 
@@ -50,13 +50,3 @@ config file arises, it will be added.
 - `HOST` sets an IP address for ingressor to listen on. Can be left empty for listening on all
   available interfaces.
 - `PORT` sets a port for ingressor to listen in. Must be within range of 0-65535 if specified.
-
-## Built With
-
-* [gin](https://github.com/gin-gonic/gin) - HTTP web framework written in Go with Martini-like API
-* [fastjson](https://github.com/valyala/fastjson) - fastest JSON parser for Go
-* [zerolog](https://github.com/rs/zerolog) - Zero Allocation JSON Logger
-
-## License
-
-[MIT © Denis Chernov](./LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.35.1
-	github.com/valyala/fastjson v1.6.10
 	golang.org/x/net v0.58.0
 	golang.org/x/sync v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
-github.com/valyala/fastjson v1.6.10 h1:/yjJg8jaVQdYR3arGxPE2X5z89xrlhS0eGXdv+ADTh4=
-github.com/valyala/fastjson v1.6.10/go.mod h1:e6FubmQouUNP73jtMLmcbxS6ydWIpOfhz34TSfO3JaE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	parserPool := &fastjson.ParserPool{}
 
-	arknightsProvider := akp.NewArknightsProvider(parserPool, http.DefaultClient)
+	arknightsProvider := akp.NewArknightsProvider(http.DefaultClient)
 	akr.NewArknightsRouter(arknightsProvider).Register(engine.Group("/arknights"))
 
 	bleepingComputerProvider := bp.NewBleepingComputerProvider(http.DefaultClient)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	trr "github.com/imcrazytwkr/feedhub/routes/tomrigby"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/valyala/fastjson"
 )
 
 func main() {
@@ -42,15 +41,13 @@ func main() {
 	engine.Use(middleware.RequestId())
 	engine.Use(middleware.ResponseFormat(engine))
 
-	parserPool := &fastjson.ParserPool{}
-
 	arknightsProvider := akp.NewArknightsProvider(http.DefaultClient)
 	akr.NewArknightsRouter(arknightsProvider).Register(engine.Group("/arknights"))
 
 	bleepingComputerProvider := bp.NewBleepingComputerProvider(http.DefaultClient)
 	br.NewBleepingComputerRouter(bleepingComputerProvider).Register(engine.Group("/bleepingcomputer"))
 
-	pixivProvider := pp.NewPixivProvider(parserPool, http.DefaultClient)
+	pixivProvider := pp.NewPixivProvider(http.DefaultClient)
 	pr.NewPixivRouter(pixivProvider).Register(engine.Group("/pixiv"))
 
 	tomRigbyProvider := trp.NewTomRigbyProvider(http.DefaultClient)

--- a/providers/arknights/mappers/news.go
+++ b/providers/arknights/mappers/news.go
@@ -1,7 +1,6 @@
 package mappers
 
 import (
-	"bytes"
 	"strconv"
 	"strings"
 	"time"
@@ -10,11 +9,14 @@ import (
 	"github.com/imcrazytwkr/feedhub/models"
 	m "github.com/imcrazytwkr/feedhub/providers/arknights/models"
 	"github.com/imcrazytwkr/feedhub/utils/feedutil"
-	"github.com/valyala/fastjson"
 )
 
-func PluckEntries(contents *fastjson.Value, language m.Language) []*models.Entry {
-	items := contents.GetArray("data", "items")
+func PluckEntries(contents *m.NewsResponse, language m.Language) []*models.Entry {
+	if contents == nil {
+		return nil
+	}
+
+	items := contents.Data.Items
 	if len(items) == 0 {
 		return nil
 	}
@@ -22,16 +24,17 @@ func PluckEntries(contents *fastjson.Value, language m.Language) []*models.Entry
 	entries := make([]*models.Entry, len(items))
 	i := 0
 	for _, item := range items {
-		id := parseId(item.Get("id"))
+		id := parseId(item.Id)
 		if len(id) == 0 {
 			continue
 		}
 
 		entries[i] = &models.Entry{
-			Title:     parseText(item.Get("title")),
-			Published: parsePublished(item.Get("publishedAt")),
+			// `Id` should be unset so that it's auto-generated in RSS-compatible format
+			Title:     strings.TrimSpace(item.Title),
+			Published: parsePublished(item.PublishedAt),
 			Link:      generateLink(id, language),
-			Content:   parseContent(item.Get("content")),
+			Content:   parseContent(item.Content),
 		}
 
 		i++
@@ -44,22 +47,8 @@ func PluckEntries(contents *fastjson.Value, language m.Language) []*models.Entry
 	return feedutil.SortEntries(entries)
 }
 
-func parseText(value *fastjson.Value) string {
-	if value == nil {
-		return ""
-	}
-
-	text, err := value.StringBytes()
-	if err != nil {
-		return ""
-	}
-
-	// bytes version works faster and makes less allocations
-	return string(bytes.TrimSpace(text))
-}
-
-func parseId(value *fastjson.Value) string {
-	id := parseText(value)
+func parseId(value string) string {
+	id := strings.TrimSpace(value)
 	if len(id) == 0 {
 		return id
 	}
@@ -72,8 +61,8 @@ func parseId(value *fastjson.Value) string {
 	return id
 }
 
-func parsePublished(value *fastjson.Value) time.Time {
-	text := parseText(value)
+func parsePublished(value string) time.Time {
+	text := strings.TrimSpace(value)
 	if len(text) == 0 {
 		return constants.TimeZero
 	}
@@ -90,26 +79,22 @@ func generateLink(id string, language m.Language) string {
 	return hostPrefixes[language] + id
 }
 
-func parseContent(value *fastjson.Value) string {
-	if value == nil {
-		return ""
-	}
-
-	array, err := value.Array()
-	if err != nil || len(array) == 0 {
+func parseContent(nodes []m.ContentNode) string {
+	if len(nodes) == 0 {
 		return ""
 	}
 
 	// Fast-tracking for the most common variant
-	if len(array) == 1 {
-		return parseText(array[0].Get("value"))
+	if len(nodes) == 1 {
+		return strings.TrimSpace(nodes[0].Value)
 	}
 
 	builder := strings.Builder{}
-	for _, node := range array {
-		text := parseText(node.Get("value"))
+	for _, node := range nodes {
+		text := strings.TrimSpace(node.Value)
 		if len(text) > 0 {
 			builder.WriteString(text)
+			builder.WriteByte('\n')
 		}
 	}
 

--- a/providers/arknights/mappers/news_test.go
+++ b/providers/arknights/mappers/news_test.go
@@ -1,34 +1,22 @@
 package mappers_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/imcrazytwkr/feedhub/models"
 	"github.com/imcrazytwkr/feedhub/providers/arknights/mappers"
 	m "github.com/imcrazytwkr/feedhub/providers/arknights/models"
 	"github.com/imcrazytwkr/feedhub/utils/testutil"
-	"github.com/valyala/fastjson"
 )
 
 func TestNewsEntriesExtraction(t *testing.T) {
-	feedFile, err := os.ReadFile("testdata/news_feed.json")
+	var contents m.NewsResponse
+	err := testutil.ReadJson("testdata/news_feed.json", &contents)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	parser := &fastjson.Parser{}
-
-	contents, err := parser.ParseBytes(feedFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if contents == nil {
-		t.Fatal("JSON data is NIL!")
-	}
-
-	entries := mappers.PluckEntries(contents, m.LanguageEn)
+	entries := mappers.PluckEntries(&contents, m.LanguageEn)
 	if len(entries) < 1 {
 		t.Fatal("No entries were parsed")
 	}

--- a/providers/arknights/models/content_node.go
+++ b/providers/arknights/models/content_node.go
@@ -1,0 +1,6 @@
+package models
+
+type ContentNode struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}

--- a/providers/arknights/models/news_data.go
+++ b/providers/arknights/models/news_data.go
@@ -1,0 +1,5 @@
+package models
+
+type NewsData struct {
+	Items []NewsItem `json:"items"`
+}

--- a/providers/arknights/models/news_item.go
+++ b/providers/arknights/models/news_item.go
@@ -1,0 +1,8 @@
+package models
+
+type NewsItem struct {
+	Id          string        `json:"id"`
+	Title       string        `json:"title"`
+	PublishedAt string        `json:"publishedAt"`
+	Content     []ContentNode `json:"content"`
+}

--- a/providers/arknights/models/news_response.go
+++ b/providers/arknights/models/news_response.go
@@ -1,0 +1,5 @@
+package models
+
+type NewsResponse struct {
+	Data NewsData `json:"data"`
+}

--- a/providers/arknights/provider.go
+++ b/providers/arknights/provider.go
@@ -2,6 +2,7 @@ package arknights
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/imcrazytwkr/feedhub/constants"
@@ -11,19 +12,14 @@ import (
 	"github.com/imcrazytwkr/feedhub/providers/arknights/mappers"
 	m "github.com/imcrazytwkr/feedhub/providers/arknights/models"
 	"github.com/rs/zerolog"
-	"github.com/valyala/fastjson"
 )
 
 type arknightsProvider struct {
-	parserPool *fastjson.ParserPool
-	client     h.ArknightsClient
+	client *h.ArknightsClient
 }
 
-func NewArknightsProvider(parserPool *fastjson.ParserPool, httpClient *http.Client) providers.ArknightsProvider {
-	return &arknightsProvider{
-		parserPool: parserPool,
-		client:     *h.NewArknightsClient(httpClient),
-	}
+func NewArknightsProvider(httpClient *http.Client) providers.ArknightsProvider {
+	return &arknightsProvider{h.NewArknightsClient(httpClient)}
 }
 
 func (p *arknightsProvider) GetNews(ctx context.Context, lang string) (*models.Feed, error) {
@@ -38,26 +34,24 @@ func (p *arknightsProvider) GetNews(ctx context.Context, lang string) (*models.F
 	// Entries from API
 	body, err := p.client.GetNews(ctx, language)
 	if err != nil {
-		log.Debug().Err(err).Str("lang", language.String()).Msg("failed to fetch news")
+		log.Debug().Str("lang", lang).Err(err).Msg("failed to fetch news")
 		return nil, err
 	}
 
-	log.Trace().Str("lang", language.String()).Msg("fetched news")
+	log.Trace().Str("lang", lang).Msg("fetched news")
 
-	parser := p.parserPool.Get()
-	defer p.parserPool.Put(parser)
-
-	payload, err := parser.ParseBytes(body)
+	var payload m.NewsResponse
+	err = json.Unmarshal(body, &payload)
 	if err != nil {
-		log.Debug().Err(err).Str("lang", language.String()).Msg("failed to parse news")
+		log.Debug().Err(err).Str("lang", lang).Msg("failed to parse news")
 		return nil, constants.ErrorMalformedBody
 	}
 
-	log.Trace().Str("lang", language.String()).Msg("successfully parsed news")
+	log.Trace().Str("lang", lang).Msg("successfully parsed news")
 
-	entries := mappers.PluckEntries(payload, language)
+	entries := mappers.PluckEntries(&payload, language)
 	if len(entries) == 0 {
-		log.Trace().Msg("no news found, exiting early")
+		log.Trace().Str("lang", lang).Msg("no news found, exiting early")
 		return nil, nil
 	}
 

--- a/providers/pixiv/mappers/constants.go
+++ b/providers/pixiv/mappers/constants.go
@@ -1,27 +1,6 @@
 package mappers
 
-import (
-	"regexp"
-)
-
-const errorKey = "error"
-const messageKey = "message"
-
-const bodyKey = "body"
-const canonicalKey = "canonical"
-const createDateKey = "createDate"
-const updateDateKey = "updateDate"
-const descriptionKey = "description"
-const descriptionHeaderKey = "descriptionHeader"
-const extraDataKey = "extraData"
-const illustsKey = "illusts"
-const metaKey = "meta"
-const pageCountKey = "pageCount"
-const titleKey = "title"
-const urlKey = "url"
-const userIdKey = "userId"
-const userNameKey = "userName"
-const worksKey = "works"
+import "regexp"
 
 var imageRe = regexp.MustCompile(`(/\d{4}/(?:\d{2}/){5}\d+)_p\d+[^\.]*\.(\w{3,})$`)
 

--- a/providers/pixiv/mappers/errors.go
+++ b/providers/pixiv/mappers/errors.go
@@ -3,18 +3,17 @@ package mappers
 import (
 	"errors"
 
-	"github.com/valyala/fastjson"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 )
 
-func processErrorFields(contents *fastjson.Value) (error, bool) {
-	if !contents.GetBool(errorKey) {
+func processErrorFields(apiError *m.ApiError) (error, bool) {
+	if apiError == nil || !apiError.Error {
 		return nil, false
 	}
 
-	message := contents.GetStringBytes(messageKey)
-	if len(message) == 0 {
+	if len(apiError.Message) == 0 {
 		return nil, true
 	}
 
-	return errors.New(string(message)), true
+	return errors.New(apiError.Message), true
 }

--- a/providers/pixiv/mappers/user_illustrations.go
+++ b/providers/pixiv/mappers/user_illustrations.go
@@ -5,37 +5,38 @@ import (
 	"strconv"
 
 	"github.com/imcrazytwkr/feedhub/constants"
-	"github.com/valyala/fastjson"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 )
 
-func PluckIllustrationIds(contents *fastjson.Value) ([]int, error) {
+func PluckIllustrationIds(contents *m.Response[m.IllustrationIDsBody]) ([]int, error) {
 	if contents == nil {
 		return nil, nil
 	}
 
-	err, hasError := processErrorFields(contents)
+	err, hasError := processErrorFields(&contents.ApiError)
 	if hasError {
 		return nil, err
 	}
 
-	payload := contents.GetObject(bodyKey, illustsKey)
-	if payload == nil || payload.Len() == 0 {
+	illusts := contents.Body.Illusts
+	targetLength := len(illusts)
+
+	if targetLength == 0 {
 		return nil, nil
 	}
 
-	targetLength := payload.Len()
 	illustKeys := make([]int, targetLength)
 	i := 0
 
-	payload.Visit(func(key []byte, _ *fastjson.Value) {
-		illustKey, err := strconv.Atoi(string(key))
+	for key := range illusts {
+		illustKey, err := strconv.Atoi(key)
 		if err != nil {
-			return
+			continue
 		}
 
 		illustKeys[i] = illustKey
 		i++
-	})
+	}
 
 	if i < targetLength {
 		return nil, constants.ErrorMalformedBody

--- a/providers/pixiv/mappers/user_illustrations_data.go
+++ b/providers/pixiv/mappers/user_illustrations_data.go
@@ -6,36 +6,37 @@ import (
 	"time"
 
 	"github.com/imcrazytwkr/feedhub/models"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 	"github.com/imcrazytwkr/feedhub/utils/feedutil"
-	"github.com/valyala/fastjson"
 )
 
-func PluckIllustrationEntries(contents *fastjson.Value) ([]*models.Entry, error) {
+func PluckIllustrationEntries(contents *m.Response[m.IllustrationDataBody]) ([]*models.Entry, error) {
 	if contents == nil {
 		return nil, nil
 	}
 
-	err, hasError := processErrorFields(contents)
+	err, hasError := processErrorFields(&contents.ApiError)
 	if hasError {
 		return nil, err
 	}
 
-	payload := contents.GetObject(bodyKey, worksKey)
-	if payload == nil || payload.Len() == 0 {
+	works := contents.Body.Works
+	targetLength := len(works)
+
+	if targetLength == 0 {
 		return nil, nil
 	}
 
-	targetLength := payload.Len()
 	illustrations := make([]*models.Entry, targetLength)
 	i := 0
 
-	payload.Visit(func(key []byte, v *fastjson.Value) {
-		entry := parseImageEntry(key, v)
+	for key, work := range works {
+		entry := parseImageEntry(key, &work)
 		if entry != nil {
 			illustrations[i] = entry
 			i++
 		}
-	})
+	}
 
 	if i == 0 {
 		return nil, nil
@@ -48,57 +49,53 @@ func PluckIllustrationEntries(contents *fastjson.Value) ([]*models.Entry, error)
 	return feedutil.SortEntries(illustrations), nil
 }
 
-func parseImageEntry(key []byte, v *fastjson.Value) *models.Entry {
+func parseImageEntry(key string, work *m.IllustrationWork) *models.Entry {
 	if len(key) == 0 {
 		return nil
 	}
 
-	link := postPrefix + string(key)
-
-	title := v.GetStringBytes(titleKey)
-	if len(title) == 0 {
+	if len(work.Title) == 0 {
 		return nil
 	}
 
-	author := v.GetStringBytes(userNameKey)
-	if len(author) == 0 {
+	if len(work.UserName) == 0 {
 		return nil
 	}
 
-	publicationDate, _ := time.Parse(time.RFC3339, string(v.GetStringBytes(createDateKey)))
-	updatedDate, _ := time.Parse(time.RFC3339, string(v.GetStringBytes(updateDateKey)))
+	publicationDate, _ := time.Parse(time.RFC3339, work.CreateDate)
+	updatedDate, _ := time.Parse(time.RFC3339, work.UpdateDate)
 	if publicationDate.IsZero() && updatedDate.IsZero() {
 		return nil
 	}
 
-	description := parseDescription(v, link)
+	link := postPrefix + key
+
+	description := parseDescription(work, link)
 	if len(description) == 0 {
 		return nil
 	}
 
 	return &models.Entry{
-		Title:     string(title),
+		Title:     work.Title,
 		Published: publicationDate,
 		Updated:   updatedDate,
-		Author:    string(author),
+		Author:    work.UserName,
 		Link:      link,
 		Content:   description,
 	}
 }
 
-func parseDescription(v *fastjson.Value, link string) string {
-	pageCount := v.GetInt(pageCountKey)
-	if pageCount == 0 {
+func parseDescription(work *m.IllustrationWork, link string) string {
+	if work.PageCount == 0 {
 		return ""
 	}
 
-	previewUrl := v.GetStringBytes(urlKey)
-	if len(previewUrl) == 0 {
+	if len(work.URL) == 0 {
 		return ""
 	}
 
 	// m[1] - post prefix, m[2] - extension
-	match := imageRe.FindSubmatch(previewUrl)
+	match := imageRe.FindStringSubmatch(work.URL)
 	if len(match) == 0 || len(match[1]) == 0 || len(match[2]) == 0 {
 		return ""
 	}
@@ -106,7 +103,7 @@ func parseDescription(v *fastjson.Value, link string) string {
 	description := strings.Builder{}
 
 	// Post images
-	for page := 0; page < pageCount; page++ {
+	for page := 0; page < work.PageCount; page++ {
 		fmt.Fprintf(
 			&description,
 			`<p><img src="%s/img-master/img%s_p%d_square1200.%s" alt="page %d cover" /></p>`,
@@ -119,9 +116,8 @@ func parseDescription(v *fastjson.Value, link string) string {
 	}
 
 	// Original description, if any
-	sourceDescription := v.GetStringBytes(descriptionKey)
-	if len(sourceDescription) > 0 {
-		fmt.Fprintf(&description, `<p>%s</p>`, sourceDescription)
+	if len(work.Description) > 0 {
+		fmt.Fprintf(&description, `<p>%s</p>`, work.Description)
 	}
 
 	description.WriteString(`<p>`)
@@ -130,9 +126,8 @@ func parseDescription(v *fastjson.Value, link string) string {
 	fmt.Fprintf(&description, `[<a href="%s">link</a>]`, link)
 
 	// Artist link
-	artistId := v.GetStringBytes(userIdKey)
-	if len(artistId) > 0 {
-		fmt.Fprintf(&description, ` [<a href="%s%s">artist</a>]`, artistPrefix, artistId)
+	if len(work.UserID) > 0 {
+		fmt.Fprintf(&description, ` [<a href="%s%s">artist</a>]`, artistPrefix, work.UserID)
 	}
 
 	// End links

--- a/providers/pixiv/mappers/user_illustrations_data_test.go
+++ b/providers/pixiv/mappers/user_illustrations_data_test.go
@@ -1,29 +1,22 @@
 package mappers_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/imcrazytwkr/feedhub/models"
 	"github.com/imcrazytwkr/feedhub/providers/pixiv/mappers"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 	"github.com/imcrazytwkr/feedhub/utils/testutil"
-	"github.com/valyala/fastjson"
 )
 
 func TestIllustrationEntriesExtraction(t *testing.T) {
-	sourceData, err := os.ReadFile("testdata/user_illustration_data_body.json")
+	var contents m.Response[m.IllustrationDataBody]
+	err := testutil.ReadJson("testdata/user_illustration_data_body.json", &contents)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	parser := &fastjson.Parser{}
-
-	contents, err := parser.ParseBytes(sourceData)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	entries, err := mappers.PluckIllustrationEntries(contents)
+	entries, err := mappers.PluckIllustrationEntries(&contents)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/pixiv/mappers/user_illustrations_test.go
+++ b/providers/pixiv/mappers/user_illustrations_test.go
@@ -1,28 +1,21 @@
 package mappers_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/imcrazytwkr/feedhub/providers/pixiv/mappers"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 	"github.com/imcrazytwkr/feedhub/utils/testutil"
-	"github.com/valyala/fastjson"
 )
 
 func TestIllustrationIdsExtraction(t *testing.T) {
-	sourceData, err := os.ReadFile("testdata/user_illustration_ids_body.json")
+	var contents m.Response[m.IllustrationIDsBody]
+	err := testutil.ReadJson("testdata/user_illustration_ids_body.json", &contents)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	parser := &fastjson.Parser{}
-
-	contents, err := parser.ParseBytes(sourceData)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ids, err := mappers.PluckIllustrationIds(contents)
+	ids, err := mappers.PluckIllustrationIds(&contents)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/pixiv/mappers/user_meta.go
+++ b/providers/pixiv/mappers/user_meta.go
@@ -2,32 +2,25 @@ package mappers
 
 import (
 	"github.com/imcrazytwkr/feedhub/models"
-	"github.com/valyala/fastjson"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 )
 
-func ExtractFeedFromUserMeta(contents *fastjson.Value) *models.Feed {
-	if contents == nil {
+func ExtractFeedFromUserMeta(meta *m.UserMeta) *models.Feed {
+	if meta == nil {
 		return nil
 	}
 
-	payload := contents.Get(bodyKey, extraDataKey, metaKey)
-	if payload == nil || payload.Type() != fastjson.TypeObject {
+	if len(meta.Title) == 0 {
 		return nil
 	}
 
-	title := payload.GetStringBytes(titleKey)
-	if len(title) == 0 {
-		return nil
-	}
-
-	link := payload.GetStringBytes(canonicalKey)
-	if len(link) == 0 {
+	if len(meta.Canonical) == 0 {
 		return nil
 	}
 
 	return &models.Feed{
-		Title:       string(title),
-		Description: string(payload.GetStringBytes(descriptionHeaderKey)),
-		Link:        string(link),
+		Title:       meta.Title,
+		Description: meta.DescriptionHeader,
+		Link:        meta.Canonical,
 	}
 }

--- a/providers/pixiv/models/api_error.go
+++ b/providers/pixiv/models/api_error.go
@@ -1,0 +1,6 @@
+package models
+
+type ApiError struct {
+	Error   bool   `json:"error"`
+	Message string `json:"message"`
+}

--- a/providers/pixiv/models/extra_data.go
+++ b/providers/pixiv/models/extra_data.go
@@ -1,0 +1,5 @@
+package models
+
+type ExtraData struct {
+	Meta UserMeta `json:"meta"`
+}

--- a/providers/pixiv/models/illustration_data_body.go
+++ b/providers/pixiv/models/illustration_data_body.go
@@ -1,0 +1,6 @@
+package models
+
+type IllustrationDataBody struct {
+	Works     map[string]IllustrationWork `json:"works"`
+	ExtraData ExtraData                   `json:"extraData"`
+}

--- a/providers/pixiv/models/illustration_ids_body.go
+++ b/providers/pixiv/models/illustration_ids_body.go
@@ -1,0 +1,17 @@
+package models
+
+import "encoding/json"
+
+type IllustrationIDsBody struct {
+	/**
+	 * Using `json.RawMessage` here skips reading and processing data which saves
+	 * on allocations and CPU resources. This is the most efficient solution when
+	 * we expect for values to be null.
+	 *
+	 * - Using `map[string]struct{}` would correctly parse "null" as `nil`,
+	 *   but will break if Pixiv starts sending primitives.
+	 * - Using `map[string]any` would try to parse and process value using
+	 *   reflection which will waste CPU cycles on things that we don't need.
+	 */
+	Illusts map[string]json.RawMessage `json:"illusts"`
+}

--- a/providers/pixiv/models/illustration_work.go
+++ b/providers/pixiv/models/illustration_work.go
@@ -1,0 +1,12 @@
+package models
+
+type IllustrationWork struct {
+	Title       string `json:"title"`
+	UserName    string `json:"userName"`
+	UserID      string `json:"userId"`
+	CreateDate  string `json:"createDate"`
+	UpdateDate  string `json:"updateDate"`
+	PageCount   int    `json:"pageCount"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}

--- a/providers/pixiv/models/response.go
+++ b/providers/pixiv/models/response.go
@@ -1,0 +1,6 @@
+package models
+
+type Response[T any] struct {
+	ApiError
+	Body T `json:"body"`
+}

--- a/providers/pixiv/models/user_meta.go
+++ b/providers/pixiv/models/user_meta.go
@@ -1,0 +1,7 @@
+package models
+
+type UserMeta struct {
+	Title             string `json:"title"`
+	DescriptionHeader string `json:"descriptionHeader"`
+	Canonical         string `json:"canonical"`
+}

--- a/providers/pixiv/provider.go
+++ b/providers/pixiv/provider.go
@@ -2,28 +2,27 @@ package pixiv
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/imcrazytwkr/feedhub/constants"
 	"github.com/imcrazytwkr/feedhub/models"
 	"github.com/imcrazytwkr/feedhub/providers"
 	h "github.com/imcrazytwkr/feedhub/providers/pixiv/http"
-	m "github.com/imcrazytwkr/feedhub/providers/pixiv/mappers"
+	"github.com/imcrazytwkr/feedhub/providers/pixiv/mappers"
+	m "github.com/imcrazytwkr/feedhub/providers/pixiv/models"
 	"github.com/imcrazytwkr/feedhub/utils/feedutil"
 	"github.com/imcrazytwkr/feedhub/utils/logutil"
 	"github.com/rs/zerolog"
-	"github.com/valyala/fastjson"
 )
 
 type pixivProvider struct {
-	parserPool *fastjson.ParserPool
-	client     *h.PixivClient
+	client *h.PixivClient
 }
 
-func NewPixivProvider(parserPool *fastjson.ParserPool, httpClient *http.Client) providers.PixivProvider {
+func NewPixivProvider(httpClient *http.Client) providers.PixivProvider {
 	return &pixivProvider{
-		parserPool: parserPool,
-		client:     h.NewPixivClient(httpClient),
+		client: h.NewPixivClient(httpClient),
 	}
 }
 
@@ -39,10 +38,8 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 
 	log.Trace().Msg("fetched illustration ids")
 
-	parser := p.parserPool.Get()
-	defer p.parserPool.Put(parser)
-
-	payload, err := parser.ParseBytes(body)
+	var idsPayload m.Response[m.IllustrationIDsBody]
+	err = json.Unmarshal(body, &idsPayload)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to parse illustration ids body")
 		return nil, constants.ErrorMalformedBody
@@ -50,7 +47,7 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 
 	log.Trace().Msg("successfully parsed illustration ids body")
 
-	illustIds, err := m.PluckIllustrationIds(payload)
+	illustIds, err := mappers.PluckIllustrationIds(&idsPayload)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to extract illustration ids")
 		return nil, models.NewHttpError(http.StatusBadGateway, err)
@@ -61,7 +58,9 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 		return nil, nil
 	}
 
-	log.Trace().Array("illust_ids", logutil.IntArray(illustIds)).Msg("parsed illustration ids")
+	log.Trace().
+		Array("illust_ids", logutil.IntArray(illustIds)).
+		Msgf("parsed %d illustration ids", len(illustIds))
 
 	/**
 	 * @TODO: consider only fetching last N illustrations for performance reasons
@@ -76,7 +75,8 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 
 	log.Trace().Msg("successfully fetched illustration data")
 
-	payload, err = parser.ParseBytes(body)
+	var dataPayload m.Response[m.IllustrationDataBody]
+	err = json.Unmarshal(body, &dataPayload)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to parse illustration data body")
 		return nil, constants.ErrorMalformedBody
@@ -84,7 +84,7 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 
 	log.Trace().Msg("successfully parsed illustration data body")
 
-	illustrations, err := m.PluckIllustrationEntries(payload)
+	illustrations, err := mappers.PluckIllustrationEntries(&dataPayload)
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to extract illustration data")
 		return nil, err
@@ -95,7 +95,9 @@ func (p *pixivProvider) GetUserIllustrations(ctx context.Context, userId int) (*
 		return nil, nil
 	}
 
-	feed := m.ExtractFeedFromUserMeta(payload)
+	log.Trace().Msgf("found %d illustrations", len(illustrations))
+
+	feed := mappers.ExtractFeedFromUserMeta(&dataPayload.Body.ExtraData.Meta)
 	if feed == nil {
 		log.Debug().Msg("could not parse user meta")
 		return nil, constants.ErrorMalformedBody


### PR DESCRIPTION
## Rationale

I have benchmarked `fastjson` against `encoding/json` implementation in a VM on Intel N100 CPU. There was no conclusive evidence to say that fastjson is any faster on *live* workloads. I should consider re-introducing it if json parsing does become a bottleneck in the future but for now it looks like the trade-off in terms of reduced code readability and structural rigidity is not worth it.

## Providers

- [x] Arknights provider
- [x] Pixiv provider